### PR TITLE
Update img2imgDataset.py

### DIFF
--- a/cgi-bin/paint_x2_unet/img2imgDataset.py
+++ b/cgi-bin/paint_x2_unet/img2imgDataset.py
@@ -36,6 +36,7 @@ def cvt2GRAY(img):
         return cv2.cvtColor(img2, cv2.COLOR_RGB2GRAY)
     else:
         # RGB image
+        return cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
 
 class ImageAndRefDataset(chainer.dataset.DatasetMixin):
 


### PR DESCRIPTION
Fix the bug in function cvt2GRAY: it couldn't handle with RGB image input because of a missing line of code, which resulted in a runtime error and caused an exception.